### PR TITLE
Upgrade Python runtime from 3.12 to 3.13

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -110,7 +110,7 @@ module api './app/api.bicep' = {
     applicationInsightsName: monitoring.outputs.name
     appServicePlanId: appServicePlan.outputs.resourceId
     runtimeName: 'python'
-    runtimeVersion: '3.12'
+    runtimeVersion: '3.13'
     storageAccountName: storage.outputs.name
     enableBlob: storageEndpointConfig.enableBlob
     enableQueue: storageEndpointConfig.enableQueue


### PR DESCRIPTION
Fixes #22

This PR upgrades the Python runtime version from 3.12 to 3.13 in the infrastructure configuration.